### PR TITLE
Missing () around IIFE causes node 6.2.1 to choke

### DIFF
--- a/node-csv-parse.js
+++ b/node-csv-parse.js
@@ -2,7 +2,7 @@
 // Created by Caleb Everett <everettcaleb95@gmail.com>
 // Licensed under GPL-2.0
 "use strict";
-!()=>{
+!(()=>{
     // ========================
     // Library
     // ========================
@@ -210,4 +210,4 @@
     module.exports.parseAsRows = getRows;
     module.exports.parseAsObjects = getRowsAsObjects;
     // Note: generator functions removed unfortunately :/
-}();
+})();


### PR DESCRIPTION
The es6 IIFE used doesn't seem to work in node 6.2.1. It seems to want to have parens around it. Tests still run fine.
